### PR TITLE
Add box shadow to differentiate posts on mobile

### DIFF
--- a/src/components/blog-post-preview/index.js
+++ b/src/components/blog-post-preview/index.js
@@ -23,7 +23,7 @@ const BlogPostPreview = ({
 		},
 	},
 }) => (
-	<div className="columns">
+	<div className={cx('columns', styles.container)}>
 		<div className={cx('column', styles.thumbnailContainer)}>
 			<GatsbyImage
 				image={image.childImageSharp.gatsbyImageData}

--- a/src/components/blog-post-preview/styles.module.scss
+++ b/src/components/blog-post-preview/styles.module.scss
@@ -1,5 +1,13 @@
 @import '../../styles/style-variables.scss';
 
+.container {
+	@include on-screens-smaller-than-small {
+		box-shadow: rgba(0, 0, 0, 0.25) 0px 54px 55px,
+			rgba(0, 0, 0, 0.12) 0px -12px 30px, rgba(0, 0, 0, 0.12) 0px 4px 6px,
+			rgba(0, 0, 0, 0.17) 0px 12px 13px, rgba(0, 0, 0, 0.09) 0px -3px 5px;
+	}
+}
+
 .title-container {
 	@media (max-width: $break-width-small) {
 		text-align: center;


### PR DESCRIPTION
## Description

On mobile when you're viewing the list of blog posts, you can't tell when one stops and one starts.

Before:
<img width="441" alt="image" src="https://user-images.githubusercontent.com/8452261/155455950-207c8b31-1396-484b-80b9-76c8fd785531.png">


After
<img width="436" alt="image" src="https://user-images.githubusercontent.com/8452261/155455999-32998aeb-4f59-45a1-9166-61b1ecc40293.png">


## Test Plan

- Verify the preview deploy looks good **on mobile**
